### PR TITLE
Browser: Add filtering options to the keyboard modal

### DIFF
--- a/Core/BSSBMasterAPI.cs
+++ b/Core/BSSBMasterAPI.cs
@@ -107,7 +107,7 @@ namespace ServerBrowser.Core
             return responseOk;
         }
 
-        public static async Task<ServerBrowseResult> Browse(int offset, string searchQuery)
+        public static async Task<ServerBrowseResult> Browse(int offset, string searchQuery, bool filterFull = false, bool filterInProgress = false, bool filterModded = false)
         {
             var queryString = HttpUtility.ParseQueryString("");
 
@@ -134,6 +134,21 @@ namespace ServerBrowser.Core
             if (!String.IsNullOrEmpty(searchQuery))
             {
                 queryString.Add("query", searchQuery);
+            }
+
+            if (filterFull)
+            {
+                queryString.Add("filterFull", "1");
+            }
+
+            if (filterInProgress)
+            {
+                queryString.Add("filterInProgress", "1");
+            }
+
+            if (filterModded)
+            {
+                queryString.Add("filterModded", "1");
             }
 
             var response = await PerformWebRequest("GET", $"/browse?{queryString}");

--- a/Core/HostedGameBrowser.cs
+++ b/Core/HostedGameBrowser.cs
@@ -29,7 +29,7 @@ namespace ServerBrowser.Core
         public static async Task LoadPage(int offset, string searchQuery, bool filterFull = false, bool filterInProgress = false, bool filterModded = false)
         {
             // Send API request
-            var result = await BSSBMasterAPI.Browse(offset, searchQuery);
+            var result = await BSSBMasterAPI.Browse(offset, searchQuery, filterFull, filterInProgress, filterModded);
 
             // Update state
             _offset = offset;
@@ -40,28 +40,11 @@ namespace ServerBrowser.Core
 
             if (_lastServerResult != null)
             {
-                // Call .ToList() to iterate through a temporary list, allowing us to remove elements from the original
-                foreach (var lobby in _lastServerResult.Lobbies.ToList())
+                foreach (var lobby in _lastServerResult.Lobbies)
                 {
-                    if (filterFull && lobby.PlayerCount >= lobby.PlayerLimit)
-                    {
-                        _lastServerResult.Lobbies.Remove(lobby);
-                        continue;
-                    }
-                    if (filterInProgress && lobby.LobbyState == MultiplayerLobbyState.GameRunning)
-                    {
-                        _lastServerResult.Lobbies.Remove(lobby);
-                        continue;
-                    }
-                    if (filterModded && lobby.IsModded)
-                    {
-                        _lastServerResult.Lobbies.Remove(lobby);
-                        continue;
-                    }
                     _lobbyObjects[lobby.Id.Value] = lobby;
                     nextLobbiesOnPage.Add(lobby);
                 }
-                _lastServerResult.Count = _lastServerResult.Lobbies.Count;
 
                 // Server message
                 if (!String.IsNullOrEmpty(_lastServerResult.Message))

--- a/ServerBrowser.csproj
+++ b/ServerBrowser.csproj
@@ -76,6 +76,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/UI/BSML/ServerBrowserViewController.bsml
+++ b/UI/BSML/ServerBrowserViewController.bsml
@@ -2,7 +2,14 @@
 
   <modal-keyboard id="searchKeyboard" move-to-center="true" value="searchValue" show-event="openSearchKeyboard"
                   hide-event="closeSearchKeyboard" clear-on-open="false" on-enter="searchKeyboardSubmit"
-                  clickerino-offerino-closerino="false"></modal-keyboard>
+                  clickerino-offerino-closerino="false">
+    <!-- <checkbox id="filterButton" pref-height="8" pref-width="30" text="Hide full lobbies"></checkbox> -->
+	  <horizontal horizontal-fit="PreferredSize" vertical-fit="PreferredSize" spacing="2" anchor-min-x="0" anchor-max-x="1.1" anchor-max-y="1.315">
+		  <button id="filterFull" pad="0" pref-height="6.15" pref-width="30" on-click="filterfullClick" text="Hide full lobbies" face-color="~filterFullColor"></button>
+		  <button id="filterInProgress" pad="0" pref-height="6.15" pref-width="40" on-click="filterInProgressClick" text="Hide games in progress" face-color="~filterInProgressColor"></button>
+		  <button id="filterModded" pad="0" pref-height="6.15" pref-width="35" on-click="filterModdedClick" text="Hide modded games" face-color="~filterModdedColor"></button>
+	  </horizontal>
+  </modal-keyboard>
   
   <vertical id="mainContentRoot">
 

--- a/UI/ViewControllers/ServerBrowserViewController.cs
+++ b/UI/ViewControllers/ServerBrowserViewController.cs
@@ -27,7 +27,7 @@ namespace ServerBrowser.UI.ViewControllers
             HostedGameBrowser.OnUpdate += LobbyBrowser_OnUpdate;
 
             SetInitialUiState();
-            HostedGameBrowser.FullRefresh(SearchValue);
+            HostedGameBrowser.FullRefresh(SearchValue, FilterFull, FilterInProgress, FilterModded);
         }
 
         public override void __Deactivate(bool removedFromHierarchy, bool deactivateGameObject, bool screenSystemDisabling)
@@ -145,6 +145,7 @@ namespace ServerBrowser.UI.ViewControllers
             {
                 StatusText.text += "\r\nMultiplayerExtensions not detected, hiding modded games";
                 StatusText.color = Color.yellow;
+                FilterModdedButton.interactable = false;
             }
 
             GameList.tableView.ReloadData();
@@ -163,7 +164,7 @@ namespace ServerBrowser.UI.ViewControllers
 
         public bool IsSearching
         {
-            get => !String.IsNullOrEmpty(SearchValue);
+            get => !String.IsNullOrEmpty(SearchValue) || FilterFull || FilterInProgress || FilterModded;
         }
         #endregion
 
@@ -203,10 +204,16 @@ namespace ServerBrowser.UI.ViewControllers
 
         [UIComponent("loadingModal")]
         public ModalView LoadingModal;
+
+        [UIComponent("filterModded")]
+        public Button FilterModdedButton;
         #endregion
 
         #region UI Events
         private string _searchValue = "";
+        private bool _filterFull = false;
+        private bool _filterInProgress = false;
+        private bool _filterModded = false;
 
         [UIValue("searchValue")]
         public string SearchValue
@@ -216,6 +223,90 @@ namespace ServerBrowser.UI.ViewControllers
             {
                 _searchValue = value;
                 NotifyPropertyChanged();
+            }
+        }
+
+        public bool FilterFull
+        {
+            get => _filterFull;
+            set
+            {
+                _filterFull = value;
+                NotifyPropertyChanged();
+                NotifyPropertyChanged(nameof(FilterFullColor));
+            }
+        }
+
+        [UIValue("filterFullColor")]
+        public string FilterFullColor
+        {
+            get
+            {
+                switch (FilterFull)
+                {
+                    case true:
+                        return "#32CD32";
+                    case false:
+                        return "#FF0000";
+                    default:
+                        return "#FF0000";
+                }
+            }
+        }
+
+        public bool FilterInProgress
+        {
+            get => _filterInProgress;
+            set
+            {
+                _filterInProgress = value;
+                NotifyPropertyChanged();
+                NotifyPropertyChanged(nameof(FilterInProgressColor));
+            }
+        }
+
+        [UIValue("filterInProgressColor")]
+        public string FilterInProgressColor
+        {
+            get
+            {
+                switch (FilterInProgress)
+                {
+                    case true:
+                        return "#32CD32";
+                    case false:
+                        return "#FF0000";
+                    default:
+                        return "#FF0000";
+                }
+            }
+        }
+
+        public bool FilterModded
+        {
+            get => _filterModded;
+            set
+            {
+                _filterModded = value;
+                NotifyPropertyChanged();
+                NotifyPropertyChanged(nameof(FilterModdedColor));
+            }
+        }
+
+        [UIValue("filterModdedColor")]
+        public string FilterModdedColor
+        {
+            get
+            {
+                switch (FilterModded)
+                {
+                    case true:
+                        return "#32CD32";
+                    case false:
+                        return "#FF0000";
+                    default:
+                        return "#FF0000";
+                }
             }
         }
 
@@ -236,7 +327,7 @@ namespace ServerBrowser.UI.ViewControllers
         private void RefreshButtonClick()
         {
             SetInitialUiState();
-            HostedGameBrowser.FullRefresh(SearchValue);
+            HostedGameBrowser.FullRefresh(SearchValue, FilterFull, FilterInProgress, FilterModded);
         }
 
         [UIAction("searchButtonClick")]
@@ -244,6 +335,24 @@ namespace ServerBrowser.UI.ViewControllers
         {
             ClearSelection();
             parserParams.EmitEvent("openSearchKeyboard");
+        }
+
+        [UIAction("filterfullClick")]
+        private void FilterFullClick()
+        {
+            FilterFull = !FilterFull;
+        }
+
+        [UIAction("filterInProgressClick")]
+        private void FilterInProgressClick()
+        {
+            FilterInProgress = !FilterInProgress;
+        }
+
+        [UIAction("filterModdedClick")]
+        private void FilterModdedClick()
+        {
+            FilterModded = !FilterModded;
         }
 
         [UIAction("createButtonClick")]


### PR DESCRIPTION
This closes #5 and adds 3 new filtering options to the search keyboard (based on #5):
- Hide full lobbies
- Hide games in progress
- Hide modded games

This works by simply using buttons that have face colors dependent on internal bool properties (`FilterFull`, `FilterInProgress`, `FilterModded`). Clicking a button simply flips the bool (which then in its `set` accessor updates the color).

The `Hide modded games` toggle has `interactable = false` when a user doesn't have MultiplayerExtensions, however, I was unable to test this because I couldn't ever find a time where someone was hosting a vanilla lobby, so the search option was always unavailable.

I haven't worked with Beat Saber modding much in the past so I may have missed some bugs or messed something up. I would definitely recommend testing for yourself and checking my changes.

Screenshots:
![image](https://user-images.githubusercontent.com/24281994/99194718-db937480-2746-11eb-80ac-58746e230bd5.png)