### PR TITLE
Upgrade BSML, specify menu type for modifiers panel (fixes #3)

### DIFF
--- a/Harmony/MpModeSelectionActivatedPatch.cs
+++ b/Harmony/MpModeSelectionActivatedPatch.cs
@@ -11,6 +11,12 @@ namespace ServerBrowser.Harmony
     {
         public static void Postfix(MultiplayerModeSelectionViewController __instance, bool firstActivation, bool addedToHierarchy, bool screenSystemEnabling)
         {
+            if (firstActivation)
+            {
+                // Core initialization event (deferred until online menu is opened)
+                Plugin.Instance.OnOnlineMenuFirstActivated();
+            }
+
             // Enable the "game browser" button (it was left in the game but unused currently)
             var btnGameBrowser = ReflectionUtil.GetField<Button, MultiplayerModeSelectionViewController>(__instance, "_gameBrowserButton");
 

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,5 +1,4 @@
-﻿using BS_Utils.Utilities;
-using IPA;
+﻿using IPA;
 using IPA.Config.Stores;
 using ServerBrowser.Assets;
 using ServerBrowser.Core;
@@ -51,8 +50,7 @@ namespace ServerBrowser
             Log = logger;
             Config = config.Generated<PluginConfig>();
 
-            // Modifiers tab (in-lobby) - register needs to happen really early for now
-            // (https://github.com/monkeymanboy/BeatSaberMarkupLanguage/issues/67)
+            // Modifiers tab (in-lobby) - registering early so we appear first
             LobbyConfigPanel.RegisterGameplayModifierTab();
         }
 
@@ -77,9 +75,6 @@ namespace ServerBrowser
             HttpClient.DefaultRequestHeaders.Add("User-Agent", Plugin.UserAgent);
             HttpClient.DefaultRequestHeaders.Add("X-BSSB", "✔");
 
-            // BS Events
-            BSEvents.lateMenuSceneLoadedFresh += OnLateMenuSceneLoadedFresh;
-
             // Start update timer
             UpdateTimer.Start();
 
@@ -98,7 +93,6 @@ namespace ServerBrowser
             UpdateTimer.Stop();
 
             // Clean up events
-            BSEvents.lateMenuSceneLoadedFresh -= OnLateMenuSceneLoadedFresh;
             MpSession.TearDown();
 
             // Try to cancel any host announcements we may have had
@@ -107,7 +101,7 @@ namespace ServerBrowser
         #endregion
 
         #region Core events
-        private void OnLateMenuSceneLoadedFresh(ScenesTransitionSetupDataSO obj)
+        internal void OnOnlineMenuFirstActivated()
         {
             // Bind multiplayer session events
             MpSession.SetUp();
@@ -133,8 +127,6 @@ namespace ServerBrowser
             PlatformId = PLATFORM_UNKNOWN;
 
             // Attempt to detect platform
-            // --> NOTE: Currently this can hang for a long time (possibly until a level is finished), depending on which mods the user is using
-            // --> This should be fixed in BS_Utils v1.6.2+
             var userInfo = await BS_Utils.Gameplay.GetUserInfo.GetUserAsync().ConfigureAwait(false);
 
             if (userInfo.platform == UserInfo.Platform.Oculus)

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -12,5 +12,5 @@ using System.Runtime.InteropServices;
 [assembly: Guid("7e8f3dda-fe61-4a71-9974-560a6bc1c286")]
 
 [assembly: AssemblyCulture("en-US")]
-[assembly: AssemblyVersion("0.2.0")]
-[assembly: AssemblyFileVersion("0.2.0")]
+[assembly: AssemblyVersion("0.3.0")]
+[assembly: AssemblyFileVersion("0.3.0")]

--- a/ServerBrowser.csproj
+++ b/ServerBrowser.csproj
@@ -49,9 +49,10 @@
     <Reference Include="BGNet">
       <HintPath>..\..\SteamLibrary\steamapps\common\Beat Saber\Beat Saber_Data\Managed\BGNet.dll</HintPath>
     </Reference>
-    <Reference Include="BSML, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="BSML, Version=1.4.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Plugins\BSML.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\SteamLibrary\steamapps\common\Beat Saber\Plugins\BSML.dll</HintPath>
     </Reference>
     <Reference Include="BS_Utils, Version=1.6.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/UI/Components/LobbyConfigPanel.cs
+++ b/UI/Components/LobbyConfigPanel.cs
@@ -232,7 +232,7 @@ namespace ServerBrowser.UI.Components
 
             if (!_tabIsAdded)
             {
-                GameplaySetup.instance.AddTab(TAB_NAME, ResourceName, LobbyConfigPanel.instance);
+                GameplaySetup.instance.AddTab(TAB_NAME, ResourceName, LobbyConfigPanel.instance, MenuType.Online);
                 Plugin.Log?.Debug("Added gameplay modifier tab (LobbyConfigPanel)");
                 _tabIsAdded = true;
             }

--- a/manifest.json
+++ b/manifest.json
@@ -3,14 +3,14 @@
   "id": "ServerBrowser",
   "name": "ServerBrowser",
   "author": "LookAtHippo",
-  "version": "0.2.0",
-  "description": "Adds a Server Browser to the Online menu, making it easy to find and join custom games without having to leave the game or exchange server codes.",
+  "version": "0.3.0",
+  "description": "Adds a Server Browser to the Online menu, making it easy to share and discover multiplayer games.",
   "gameVersion": "1.13.0",
   "dependsOn": {
     "BSIPA": "^4.1.3",
-    "BeatSaberMarkupLanguage": "^1.4.0",
-    "SongCore": "^3.0.0",
-    "BS Utils": "^1.6.2"
+    "BeatSaberMarkupLanguage": "^1.4.3",
+    "SongCore": "^3.0.3",
+    "BS Utils": "^1.6.5"
   },
   "links": {
     "project-home": "https://bssb.app",


### PR DESCRIPTION
This pull request:
 - Upgrades BSML to v1.4.3 (not on BeatMods yet)
 - Specifies `MenuType.Online` so the modifiers panel is not shown in single player (issue #3)
 - Updated references to SongCore and BS Utils (to match latest versions on BeatMods)
 - Removes the dependency on BSEvents as our load-event (late fresh menu scene loaded) stopped working for some reason
 - Bumps ServerBrowser to 0.3.0

Before this is ready to merge: need to test a bit more and wait for BSML to be updated on BeatMods.