### PR TITLE
Report correct player limit

### DIFF
--- a/Core/BssbDataCollector.cs
+++ b/Core/BssbDataCollector.cs
@@ -16,6 +16,7 @@ namespace ServerBrowser.Core
     {
         [Inject] private readonly SiraLog _log = null!;
         [Inject] private readonly IMultiplayerSessionManager _multiplayerSession = null!;
+        [Inject] private readonly IUnifiedNetworkPlayerModel _unifiedNetworkPlayerModel = null!;
         [Inject] private readonly ServerBrowserClient _serverBrowserClient = null!;
 
         public bool SessionActive { get; private set; }
@@ -55,13 +56,7 @@ namespace ServerBrowser.Core
 
             if (IsPartyLeader)
             {
-                // If we're the instance creator, session "maxPlayerCount" will be what they entered on Create Server
-                //  Otherwise, this value won't be updated so we can't use it
-
-                // This value also does NOT work for BeatTogether as their master doesn't set the right Manager ID, but
-                //  that's not an issue because their maxPlayerCount is accurate in the pre connect info.
-
-                Current.PlayerLimit = _multiplayerSession.maxPlayerCount;
+                Current.PlayerLimit = _unifiedNetworkPlayerModel.configuration.maxPlayerCount;
                 Current.Name = _serverBrowserClient.PreferredServerName;
 
                 _log.Info($"MaxPlayerCount updated to {Current.PlayerLimit} (workaround for official servers)");


### PR DESCRIPTION
Use `UnifiedNetworkPlayerModel` to get the actual player limit instead of the requested one.

127 player room, without patch:
![before](https://user-images.githubusercontent.com/25163630/149983028-6aab69a0-0677-4268-922b-e0d862165835.png)

with patch:
![after](https://user-images.githubusercontent.com/25163630/149983041-5c594fa2-0926-4e4e-852d-3eebda7a7926.png)

Tested on my WIP self-hosted master server